### PR TITLE
Lead and Deal Sources

### DIFF
--- a/basecrm.gemspec
+++ b/basecrm.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |spec|
   spec.test_files = Dir["spec/**/*"]
 
   spec.add_dependency "faraday", "~> 0.9", ">= 0.9.0"
-  spec.add_dependency "json", "~> 1.7", ">= 1.7.7"
+  spec.add_dependency "json", "~> 2.0"
 
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "rspec-collection_matchers", "~> 1.1"
   spec.add_development_dependency "fuubar", "~> 2.0"
-  spec.add_development_dependency "factory_girl", "~> 4.5"
+  spec.add_development_dependency "factory_girl", "~> 4.8"
   spec.add_development_dependency "faker", "~> 1.4"
 end

--- a/lib/basecrm/services/leads_service.rb
+++ b/lib/basecrm/services/leads_service.rb
@@ -2,24 +2,24 @@
 
 module BaseCRM
   class LeadsService
-    OPTS_KEYS_TO_PERSIST = Set[:address, :custom_fields, :description, :email, :facebook, :fax, :first_name, :industry, :last_name, :linkedin, :mobile, :organization_name, :owner_id, :phone, :skype, :status, :tags, :title, :twitter, :website]
+    OPTS_KEYS_TO_PERSIST = Set[:address, :custom_fields, :description, :email, :facebook, :fax, :first_name, :industry, :last_name, :linkedin, :mobile, :organization_name, :owner_id, :phone, :skype, :status, :tags, :title, :twitter, :website, :source_id]
 
     def initialize(client)
       @client = client
     end
 
     # Retrieve all leads
-    # 
+    #
     # get '/leads'
     #
     # If you want to use filtering or sorting (see #where).
-    # @return [Enumerable] Paginated resource you can use to iterate over all the resources. 
+    # @return [Enumerable] Paginated resource you can use to iterate over all the resources.
     def all
       PaginatedResource.new(self)
     end
 
     # Retrieve all leads
-    # 
+    #
     # get '/leads'
     #
     # Returns all leads available to the user, according to the parameters provided
@@ -38,23 +38,23 @@ module BaseCRM
     # @option options [Integer] :per_page (25) Number of records to return per page. The default limit is *25* and the maximum number that can be returned is *100*.
     # @option options [String] :sort_by (updated_at:asc) A field to sort by. The **default** order is **ascending**. If you want to change the sort order to descending, append `:desc` to the field e.g. `sort_by=last_name:desc`.
     # @option options [String] :status Status of the lead.
-    # @return [Array<Lead>] The list of Leads for the first page, unless otherwise specified. 
+    # @return [Array<Lead>] The list of Leads for the first page, unless otherwise specified.
     def where(options = {})
       _, _, root = @client.get("/leads", options)
 
       root[:items].map{ |item| Lead.new(item[:data]) }
     end
-    
+
 
     # Create a lead
-    # 
+    #
     # post '/leads'
     #
     # Creates a new lead
     # A lead may represent a single individual or an organization
     #
-    # @param lead [Lead, Hash] Either object of the Lead type or Hash. This object's attributes describe the object to be created. 
-    # @return [Lead] The resulting object represting created resource. 
+    # @param lead [Lead, Hash] Either object of the Lead type or Hash. This object's attributes describe the object to be created.
+    # @return [Lead] The resulting object represting created resource.
     def create(lead)
       validate_type!(lead)
 
@@ -63,26 +63,26 @@ module BaseCRM
 
       Lead.new(root[:data])
     end
-    
+
 
     # Retrieve a single lead
-    # 
+    #
     # get '/leads/{id}'
     #
     # Returns a single lead available to the user, according to the unique lead ID provided
     # If the specified lead does not exist, this query returns an error
     #
     # @param id [Integer] Unique identifier of a Lead
-    # @return [Lead] Searched resource object. 
+    # @return [Lead] Searched resource object.
     def find(id)
       _, _, root = @client.get("/leads/#{id}")
 
       Lead.new(root[:data])
     end
-    
+
 
     # Update a lead
-    # 
+    #
     # put '/leads/{id}'
     #
     # Updates lead information
@@ -92,8 +92,8 @@ module BaseCRM
     # `tags` are replaced every time they are used in a request
     # </figure>
     #
-    # @param lead [Lead, Hash] Either object of the Lead type or Hash. This object's attributes describe the object to be updated. 
-    # @return [Lead] The resulting object represting updated resource. 
+    # @param lead [Lead, Hash] Either object of the Lead type or Hash. This object's attributes describe the object to be updated.
+    # @return [Lead] The resulting object represting updated resource.
     def update(lead)
       validate_type!(lead)
       params = extract_params!(lead, :id)
@@ -104,10 +104,10 @@ module BaseCRM
 
       Lead.new(root[:data])
     end
-    
+
 
     # Delete a lead
-    # 
+    #
     # delete '/leads/{id}'
     #
     # Delete an existing lead
@@ -120,7 +120,7 @@ module BaseCRM
       status, _, _ = @client.delete("/leads/#{id}")
       status == 204
     end
-    
+
 
   private
     def validate_type!(lead)
@@ -132,7 +132,7 @@ module BaseCRM
       raise ArgumentError, "one of required attributes is missing. Expected: #{args.join(',')}" if params.count != args.length
       params
     end
-       
+
     def sanitize(lead)
       lead.to_h.select { |k, _| OPTS_KEYS_TO_PERSIST.include?(k) }
     end

--- a/lib/basecrm/services/sources_service.rb
+++ b/lib/basecrm/services/sources_service.rb
@@ -32,7 +32,7 @@ module BaseCRM
     # @option options [String] :sort_by (id:asc) A field to sort by. The **default** ordering is **ascending**. If you want to change the sort order to descending, append `:desc` to the field e.g. `sort_by=name:desc`.
     # @return [Array<Source>] The list of Sources for the first page, unless otherwise specified.
     def where(options = {})
-      path = resource_type(options[:resource_type])
+      path = resource_type(options.delete(:resource_type))
 
       _, _, root = @client.get(path, options)
 
@@ -56,7 +56,7 @@ module BaseCRM
 
       attributes = sanitize(source)
 
-      path = resource_type(options[:resource_type])
+      path = resource_type(options.delete(:resource_type))
 
       _, _, root = @client.post(path, attributes)
 
@@ -74,7 +74,7 @@ module BaseCRM
     # @param id [Integer] Unique identifier of a Source
     # @return [Source] Searched resource object.
     def find(id, options = {})
-      path = resource_type(options[:resource_type])
+      path = resource_type(options.delete(:resource_type))
 
       _, _, root = @client.get("#{path}/#{id}")
 
@@ -98,7 +98,7 @@ module BaseCRM
       validate_type!(source)
       params = extract_params!(source, :id)
       id = params[:id]
-      path = resource_type(options[:resource_type])
+      path = resource_type(options.delete(:resource_type))
 
       attributes = sanitize(source)
       _, _, root = @client.put("#{path}/#{id}", attributes)
@@ -118,7 +118,7 @@ module BaseCRM
     # @param id [Integer] Unique identifier of a Source
     # @return [Boolean] Status of the operation.
     def destroy(id, options = {})
-      path = resource_type(options[:resource_type])
+      path = resource_type(options.delete(:resource_type))
 
       status, _, _ = @client.delete("#{path}/#{id}")
       status == 204

--- a/spec/factories/source.rb
+++ b/spec/factories/source.rb
@@ -5,7 +5,16 @@ FactoryGirl.define do
 
 
     to_create do |source|
-      client.sources.create(source)
+      client.sources.create(source, resource_type: source.resource_type)
+    end
+
+    factory :lead_source do
+      resource_type 'lead'
+    end
+
+    factory :deal_source do
+      resource_type 'deal'
     end
   end
+
 end

--- a/spec/services/sources_service_spec.rb
+++ b/spec/services/sources_service_spec.rb
@@ -10,7 +10,7 @@ describe BaseCRM::SourcesService do
     it { should respond_to :find }
     it { should respond_to :update }
     it { should respond_to :where }
- 
+
   end
 
   describe :all do
@@ -23,6 +23,14 @@ describe BaseCRM::SourcesService do
     it "returns an array" do
       expect(client.sources.where(page: 1)).to be_an Array
     end
+
+    it "returns lead sources when resource_type is 'lead'" do
+      expect(client.sources.where(page: 1, resource_type: 'lead').first[:resource_type]).to eq("lead")
+    end
+
+    it "returns deal sources when resource_type is 'deal'" do
+      expect(client.sources.where(page: 1, resource_type: 'deal').first[:resource_type]).to eq("deal")
+    end
   end
 
   describe :create do
@@ -30,29 +38,72 @@ describe BaseCRM::SourcesService do
       @source = build(:source)
       expect(client.sources.create(@source)).to be_instance_of BaseCRM::Source
     end
+
+    it "returns new lead source when resource_type is 'lead'" do
+      @source = build(:lead_source)
+      expect(client.sources.create(@source, resource_type: 'lead').resource_type).to eq("lead")
+    end
+
+    it "returns new deal source when resource_type is 'deal'" do
+      @source = build(:deal_source)
+      expect(client.sources.create(@source, resource_type: 'deal').resource_type).to eq("deal")
+    end
   end
 
   describe :find do
     before :each do
-      @source = create(:source) 
+      @source = create(:source)
+      @lead_source = create(:lead_source)
     end
 
     it "returns an instance of Source class" do
       expect(client.sources.find(@source.id)).to be_instance_of BaseCRM::Source
     end
+
+    it "returns a lead source when resource_type is 'lead'" do
+      expect(client.sources.find(@lead_source.id, resource_type: 'lead').resource_type).to eq 'lead'
+    end
+
+    it "returns a lead source when resource_type is 'lead'" do
+      expect(client.sources.find(@source.id, resource_type: 'deal').resource_type).to eq 'deal'
+    end
   end
 
   describe :update do
-    it "returns an updated instance of Source class" do
+    before :each do
       @source = create(:source)
+      @lead_source = create(:lead_source)
+    end
+
+    it "returns an updated instance of Source class" do
       expect(client.sources.update(@source)).to be_instance_of BaseCRM::Source
+    end
+
+    it "returns a lead source when resource_type is 'lead'" do
+      expect(client.sources.update(@lead_source, resource_type: 'lead').resource_type).to eq 'lead'
+    end
+
+    it "returns a deal source when resource_type is 'deal'" do
+      expect(client.sources.update(@source, resource_type: 'deal').resource_type).to eq 'deal'
     end
   end
 
   describe :destroy do
-    it "returns true on success" do
+    before :each do
       @source = create(:source)
+      @lead_source = create(:lead_source)
+    end
+
+    it "returns true on success" do
       expect(client.sources.destroy(@source.id)).to be_truthy
+    end
+
+    it "returns true when when resource_type is 'lead'" do
+      expect(client.sources.destroy(@lead_source.id, resource_type: 'lead')).to be_truthy
+    end
+
+    it "returns true when resource_type is 'deal'" do
+      expect(client.sources.destroy(@source.id, resource_type: 'deal')).to be_truthy
     end
   end
 end

--- a/spec/services/sources_service_spec.rb
+++ b/spec/services/sources_service_spec.rb
@@ -64,7 +64,7 @@ describe BaseCRM::SourcesService do
       expect(client.sources.find(@lead_source.id, resource_type: 'lead').resource_type).to eq 'lead'
     end
 
-    it "returns a lead source when resource_type is 'lead'" do
+    it "returns a deal source when resource_type is 'deal'" do
       expect(client.sources.find(@source.id, resource_type: 'deal').resource_type).to eq 'deal'
     end
   end


### PR DESCRIPTION
This change introduces the ability to provide a `resource_type` argument to each of the SourcesService methods (except for `.all`) to differentiate between Deal and Lead sources.

Prior to this change, SourcesService would only hit the `/sources` API endpoint, which would only return Deal Sources. This change allows the caller to specify the type of Source they want to work with without introducing any duplication.

Related specs and factories have been updated and are passing.

This approach may not be feasible given that you auto-generate your API through a JSON schema but we required this functionality internally and, not having access to your JSON schema, needed to patch together a suitable solution.

Ideally there would be the equivalent to a `find_or_create_source` or `upsert` method for Sources since it now requires two API calls to create a Source that doesn't already exist.
