### PR TITLE
Fix deal creation with hash as argument

### DIFF
--- a/lib/basecrm/services/deals_service.rb
+++ b/lib/basecrm/services/deals_service.rb
@@ -131,8 +131,9 @@ module BaseCRM
     end
        
     def sanitize(deal)
-      deal.value = Coercion.to_string(deal.value)
-      deal.to_h.select { |k, _| OPTS_KEYS_TO_PERSIST.include?(k) }
+      deal_hash = deal.to_h.select { |k, _| OPTS_KEYS_TO_PERSIST.include?(k) }
+      deal_hash[:value] = Coercion.to_string(deal_hash[:value])
+      deal_hash
     end
   end
 end

--- a/spec/services/deals_service_spec.rb
+++ b/spec/services/deals_service_spec.rb
@@ -27,8 +27,13 @@ describe BaseCRM::DealsService do
 
   describe :create do
     it "returns instance of Deal class" do
-      @deal = build(:deal)
-      expect(client.deals.create(@deal)).to be_instance_of BaseCRM::Deal
+      deal = build(:deal)
+      expect(client.deals.create(deal)).to be_instance_of BaseCRM::Deal
+    end
+
+    it "allows to create a Deal with hash of parameters" do
+      deal = attributes_for(:deal)
+      expect(client.deals.create(deal)).to be_instance_of BaseCRM::Deal
     end
   end
 


### PR DESCRIPTION
Fix a bug introduced in 78112f2 where it was impossible to create a deal
by just passing a hash to `create`. `sanitize` method was expecting
passed argument to respond to value which in case of hash was failing.
