### PR TITLE
update gemspec license and authors

### DIFF
--- a/basecrm.gemspec
+++ b/basecrm.gemspec
@@ -10,10 +10,10 @@ Gem::Specification.new do |spec|
   spec.summary       = "BaseCRM Official API V2 library client for ruby"
   spec.description   = "BaseCRM Official API V2 library client for ruby"
 
-  spec.authors       = ["BaseCRM developers"]
-  spec.email         = ["developers@getbase.com"]
+  spec.authors       = ["Zendesk"]
+  spec.email         = ["opensource@zendesk.com"]
   spec.homepage      = "https://github.com/basecrm/basecrm-ruby"
-  spec.license       = "MIT"
+  spec.license       = "Apache License Version 2.0"
 
   spec.require_paths = ["lib"]
 

--- a/lib/basecrm/version.rb
+++ b/lib/basecrm/version.rb
@@ -1,3 +1,3 @@
 module BaseCRM
-  VERSION = "1.3.6"
+  VERSION = "1.3.7"
 end


### PR DESCRIPTION
update gemspec with updated license to Apache 2 and use company wide author and email Zendesk and opensource@zendesk.com. to release in rubygems patch version is bumped.